### PR TITLE
refacto(chore): moving some stuff somewhere else

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -26,7 +26,7 @@
     [
       "babel-plugin-transform-require-ignore",
       {
-        "extensions": [".scss"]
+        "extensions": []
       }
     ],
     [

--- a/src/player/components/eventBus.js
+++ b/src/player/components/eventBus.js
@@ -1,4 +1,5 @@
 import { ALL } from '../constants/events';
+import { logger } from '../service/logger';
 
 export const eventBus = new class EventBus {
   constructor() {
@@ -26,7 +27,7 @@ export const eventBus = new class EventBus {
       try {
         listener(event);
       } catch (error) {
-        console.warn(error);
+        logger.warn(error);
       }
     });
   };

--- a/src/player/components/mediaSource.js
+++ b/src/player/components/mediaSource.js
@@ -23,7 +23,7 @@ export class MediaSource {
 
     this.tracks.forEach(type => {
       const adaptationSet = this.currentPeriod.findAdaptationSetByType(type);
-      this.fragmentManager.initFragments(adaptationSet, this.increaseBuffer(type));
+      this.fragmentManager.initFragments(adaptationSet, this.appendBuffer(type));
     });
   };
 
@@ -35,5 +35,5 @@ export class MediaSource {
     return new SourceBuffer(buffer);
   }
 
-  increaseBuffer = type => bytes => this.buffers[type].append({ bytes });
+  appendBuffer = type => bytes => this.buffers[type].append({ bytes });
 }

--- a/src/player/components/mediaSource.js
+++ b/src/player/components/mediaSource.js
@@ -1,8 +1,8 @@
 import { SourceBuffer } from './sourceBuffer';
 
 export class MediaSource {
-  constructor(period, windowMediaSource, tracks, fragmentManager) {
-    this.mediaSource = windowMediaSource;
+  constructor(period, tracks, fragmentManager) {
+    this.mediaSource = new window.MediaSource();
     this.tracks = tracks;
     this.queue = [];
     this.buffers = {};
@@ -11,6 +11,8 @@ export class MediaSource {
 
     this.mediaSource.addEventListener('sourceopen', this.onSourceOpen);
   }
+
+  mediaUrl = () => URL.createObjectURL(this.mediaSource);
 
   setCurrentPeriod = period => {
     this.currentPeriod = period;

--- a/src/player/components/mediaSource.js
+++ b/src/player/components/mediaSource.js
@@ -1,12 +1,12 @@
 import { SourceBuffer } from './sourceBuffer';
 
 export class MediaSource {
-  constructor(period, windowMediaSource, tracks, fm) {
+  constructor(period, windowMediaSource, tracks, fragmentManager) {
     this.mediaSource = windowMediaSource;
     this.tracks = tracks;
     this.queue = [];
     this.buffers = {};
-    this.fm = fm;
+    this.fragmentManager = fragmentManager;
     this.currentPeriod = period;
 
     this.mediaSource.addEventListener('sourceopen', this.onSourceOpen);
@@ -21,7 +21,7 @@ export class MediaSource {
 
     this.tracks.forEach(type => {
       const adaptationSet = this.currentPeriod.findAdaptationSetByType(type);
-      this.fm.initFragments(adaptationSet, this.increaseBuffer(type));
+      this.fragmentManager.initFragments(adaptationSet, this.increaseBuffer(type));
     });
   };
 

--- a/src/player/components/sourceBuffer.js
+++ b/src/player/components/sourceBuffer.js
@@ -1,22 +1,23 @@
 export class SourceBuffer {
-  constructor(mediaSource, codec) {
+  constructor(buffer) {
     this.queue = [];
 
-    this.buffer = mediaSource.addSourceBuffer(codec);
+    this.buffer = buffer;
     this.buffer.addEventListener('updateend', this.onSourceBufferUpdateEnd);
   }
 
   append(segment) {
     if (this.buffer.updating) {
-      this.queue.push(segment);
-    } else {
-      this.buffer.appendBuffer(segment.bytes);
+      return this.queue.push(segment);
     }
+
+    return this.buffer.appendBuffer(segment.bytes);
   }
 
   onSourceBufferUpdateEnd = () => {
     if (this.queue.length) {
       const segment = this.queue.pop();
+
       this.buffer.appendBuffer(segment.bytes);
     }
   };

--- a/src/player/model/adaptationSet.js
+++ b/src/player/model/adaptationSet.js
@@ -42,6 +42,4 @@ export class AdaptationSet {
   readableInitializer() {
     return this.makeReadable('initialization');
   }
-
-  makeUrl() {}
 }

--- a/src/player/model/adaptationSet.js
+++ b/src/player/model/adaptationSet.js
@@ -18,4 +18,30 @@ export class AdaptationSet {
     this.attributes = attributes;
     this.segmentTemplate = segmentTemplate;
   }
+
+  mimeType() {
+    const { codecs } = this.representations[0].attributes;
+
+    return `${this.attributes.mimeType}; codecs="${codecs}"`;
+  }
+
+  countSegment() {
+    return Math.round(30 / (this.segmentTemplate.duration / 1000));
+  }
+
+  makeReadable(field) {
+    const { id } = this.representations[0].attributes;
+
+    return this.segmentTemplate[field].replace(/\$RepresentationID\$/g, id);
+  }
+
+  readableMedia(number) {
+    return this.makeReadable('media').replace('$Number$', number);
+  }
+
+  readableInitializer() {
+    return this.makeReadable('initialization');
+  }
+
+  makeUrl() {}
 }

--- a/src/player/model/manifest.js
+++ b/src/player/model/manifest.js
@@ -16,5 +16,9 @@ export class Manifest {
     this.baseUrl = baseUrl;
   }
 
+  generateUrl() {
+    return this.url.substring(0, this.url.lastIndexOf('/') + 1) + this.baseUrl;
+  }
+
   getCurrentPeriod = () => this.periods[0];
 }

--- a/src/player/model/manifest.js
+++ b/src/player/model/manifest.js
@@ -16,9 +16,7 @@ export class Manifest {
     this.baseUrl = baseUrl;
   }
 
-  generateUrl() {
-    return this.url.substring(0, this.url.lastIndexOf('/') + 1) + this.baseUrl;
-  }
+  generateUrl = () => this.url.substring(0, this.url.lastIndexOf('/') + 1) + this.baseUrl;
 
   getCurrentPeriod = () => this.periods[0];
 }

--- a/src/player/model/period.js
+++ b/src/player/model/period.js
@@ -9,5 +9,5 @@ export class Period {
     this.adaptationSets = adaptationSets;
   }
 
-  getAdaptationSetFor = type => this.adaptationSets.find(({ attributes: { mimeType } }) => mimeType.includes(type));
+  findAdaptationSetByType = type => this.adaptationSets.find(({ attributes: { mimeType } }) => mimeType.includes(type));
 }

--- a/src/player/player.js
+++ b/src/player/player.js
@@ -22,13 +22,12 @@ export class Player {
         manifest.url = url;
 
         const fm = new FragmentManager(manifest.generateUrl());
-        const wMediaSource = new window.MediaSource();
 
         eventBus.triggerEvent({ type: MANIFEST_LOADED, manifest });
 
-        const mediaSource = new MediaSource(manifest.getCurrentPeriod(), wMediaSource, ['video', 'audio'], fm);
+        const mediaSource = new MediaSource(manifest.getCurrentPeriod(), ['video', 'audio'], fm);
 
-        this.videoRef.src = URL.createObjectURL(wMediaSource);
+        this.videoRef.src = mediaSource.mediaUrl();
       });
   }
 

--- a/src/player/player.js
+++ b/src/player/player.js
@@ -4,6 +4,7 @@ import { MediaSource } from './components/mediaSource';
 import { MANIFEST_LOADED } from './constants/events';
 
 import { Manifest } from './model/manifest';
+import { FragmentManager } from '../player/service/fragmentManager';
 
 export class Player {
   constructor(videoRef) {
@@ -16,17 +17,18 @@ export class Player {
       .then(response => response.text())
       .then(str => new window.DOMParser().parseFromString(str, 'text/xml'))
       .then(xml => {
-        console.log(xml);
-
         const manifest = Manifest.createFrom(xml);
+
         manifest.url = url;
+
+        const fm = new FragmentManager(manifest.generateUrl());
+        const wMediaSource = new window.MediaSource();
 
         eventBus.triggerEvent({ type: MANIFEST_LOADED, manifest });
 
-        const mediaSource = new MediaSource(this.videoRef, manifest);
-        mediaSource.loadManifest(manifest);
+        const mediaSource = new MediaSource(manifest.getCurrentPeriod(), wMediaSource, ['video', 'audio'], fm);
 
-        this.videoRef.src = mediaSource.getObjectURL();
+        this.videoRef.src = URL.createObjectURL(wMediaSource);
       });
   }
 

--- a/src/player/service/fragmentManager.js
+++ b/src/player/service/fragmentManager.js
@@ -1,0 +1,31 @@
+export class FragmentManager {
+  constructor(baseUrl) {
+    this.baseUrl = baseUrl;
+  }
+
+  initFragments = (adaptationSet, callback) => {
+    const initialization = adaptationSet.readableInitializer();
+    const initFragmentUrl = this.baseUrl + initialization;
+
+    this.fetchFragment(initFragmentUrl, callback).then(() => this.fetchFragments(adaptationSet, callback));
+  };
+
+  fetchFragments(adaptationSet, callback) {
+    const segmentsCounts = adaptationSet.countSegment();
+
+    let promise = Promise.resolve();
+
+    for (let fragmentNumber = 1; fragmentNumber <= segmentsCounts; fragmentNumber++) {
+      const media = adaptationSet.readableMedia(fragmentNumber);
+      promise = promise.then(() => this.fetchFragment(this.baseUrl + media, callback));
+    }
+
+    return promise;
+  }
+
+  fetchFragment(url, callback) {
+    return fetch(url)
+      .then(response => response.arrayBuffer())
+      .then(callback);
+  }
+}

--- a/src/player/service/logger.js
+++ b/src/player/service/logger.js
@@ -1,0 +1,5 @@
+export const logger = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  errror: console.error.bind(console),
+};


### PR DESCRIPTION
There's something a bit weird from my POV in mediasource:

- we're looking for getters so deep in the tree, maybe we should create computation instead of doing them manually (like `getter() + getter()`, we could make better i think)

- the way we rely on `type` in this same file makes me think of inheritance code smell

- I don't get the real difference between `window.mediaSource`and our `mediaSource`